### PR TITLE
Modified exec_command to understand multi option command put "ssl" next last command.

### DIFF
--- a/lgtv_init.lua
+++ b/lgtv_init.lua
@@ -52,7 +52,13 @@ end
 
 function exec_command(command)
   if lgtv_ssl then
-    command = command.." ssl"
+    space_loc = command:find(" ")
+
+    if space_loc then
+      command = command:sub(1,space_loc).."ssl "..command:sub(space_loc+1)
+    else
+      command = command.." ssl"
+    end
   end
 
   command = lgtv_cmd.." "..command
@@ -62,10 +68,6 @@ function exec_command(command)
   end
 
   return hs.execute(command)
-end
-
-function lgtv_disabled()
-  return file_exists("./disable_lgtv") or file_exists(os.getenv('HOME') .. "/.disable_lgtv")
 end
 
 if debug then

--- a/lgtv_init.lua
+++ b/lgtv_init.lua
@@ -54,6 +54,7 @@ function exec_command(command)
   if lgtv_ssl then
     space_loc = command:find(" ")
 
+    --- "ssl" must be the first argument for commands like 'startApp'. Advance it to the expected position.
     if space_loc then
       command = command:sub(1,space_loc).."ssl "..command:sub(space_loc+1)
     else


### PR DESCRIPTION
"ssl" is need to put just next of second command part when using current version lgtv [commit link](https://github.com/klattimer/LGWebOSRemote/commit/514be54225986aa2c14f6fd12ddef7bbc4378cc1) 

Example:
lgtv MyTV startApp com.webos.app.hdmi1 ssl --> fails
lgtv MyTV startApp ssl com.webos.app.hdmi1 --> success

Therefore I added step to put "ssl" next of second command part in exec_command.