### PR TITLE
Support for controlling TV audio via volume/mute keys

### DIFF
--- a/lgtv_init.lua
+++ b/lgtv_init.lua
@@ -2,7 +2,7 @@ local tv_input = "HDMI_1" -- Input to which your Mac is connected
 local switch_input_on_wake = true -- Switch input to Mac when waking the TV
 local prevent_sleep_when_using_other_input = true -- Prevent sleep when TV is set to other input (ie: you're watching Netflix and your Mac goes to sleep)
 local debug = false -- If you run into issues, set to true to enable debug messages
-local disable_audio_control = false -- Ignore volume and mute button events for controlling TV audio
+local control_audio = true -- Control TV volume and mute button events from keyboard
 local disable_lgtv = false
 -- NOTE: You can disable this script by setting the above variable to true, or by creating a file named
 -- `disable_lgtv` in the same directory as this file, or at ~/.disable_lgtv.
@@ -236,6 +236,6 @@ end)
 
 watcher:start()
 
-if not disable_audio_control then
+if control_audio then
   tap:start()
 end

--- a/lgtv_init.lua
+++ b/lgtv_init.lua
@@ -2,8 +2,8 @@ local tv_input = "HDMI_1" -- Input to which your Mac is connected
 local switch_input_on_wake = true -- Switch input to Mac when waking the TV
 local prevent_sleep_when_using_other_input = true -- Prevent sleep when TV is set to other input (ie: you're watching Netflix and your Mac goes to sleep)
 local debug = false -- If you run into issues, set to true to enable debug messages
-local disable_lgtv = false
 local disable_audio_control = false -- Ignore volume and mute button events for controlling TV audio
+local disable_lgtv = false
 -- NOTE: You can disable this script by setting the above variable to true, or by creating a file named
 -- `disable_lgtv` in the same directory as this file, or at ~/.disable_lgtv.
 


### PR DESCRIPTION
Hello,

I've added support to use keyboard volume and mute keys to control the TVs audio.

Features:

* Allows for volume control (volume up/volume down) and mute/unmute toggle
* Can be disabled by changing one flag (can be disabled by default)
* Check if the TV is the current audio device each time a key event is detected. Only react to events when true
* Works with built-in and external keyboards (only tested on M1 Macbook Pro and Keychron K8)

Loads the following additional Hammerspoon extensions:
* eventtap
* audiodevice
* json