### PR TITLE
fix name of Lua script in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Now, try the following:
 
 If everything is working as expected, your screen should turn off.
 
-Change the HDMI input at the top of `~/.hammerspoon/init_lgtv.lua` script, if needed.
+Change the HDMI input at the top of `~/.hammerspoon/lgtv_init.lua` script, if needed.
 
 ## Special Thanks
 


### PR DESCRIPTION
Corrects the filename of the lgtv_init.lua configuration script so that the given command runs correctly.