### PR TITLE
Clarify docs for hammerspoon config

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,12 @@ cd lg-tv-control-macos
 ```
 
 ### Configuration
-Change the HDMI input at the top of `~/.hammerspoon/lgtv.lua` script, if needed. Optionally, set `debug` to `true` if you are running into issues.
+
+Edit `~/.hammerspoon/lgtv.lua` to customize the script's behavior:
+
+- **`tv_input`** — Set this to the HDMI port your Mac is connected to (e.g., `"HDMI_1"`, `"HDMI_2"`, `"HDMI_3"`, `"HDMI_4"`). Default is `"HDMI_1"`.
+- **`screen_off_command`** — Set to `"power_off"` to fully turn off the TV when your Mac sleeps. Default is `"screen_off"`, which only blanks the display.
+- **`debug`** — Set to `true` to enable debug logging if you are running into issues.
 
 
 ## Legacy version using LGWebOSRemote


### PR DESCRIPTION
## Summary
- Document `tv_input`, `screen_off_command`, and `debug` options in the Configuration section
- Clarify that `screen_off_command` can be set to `"power_off"` to fully turn off the TV on sleep (default only blanks the display)